### PR TITLE
Don't edit SConstruct file in the manifest

### DIFF
--- a/io.github.endless_sky.endless_sky.json
+++ b/io.github.endless_sky.endless_sky.json
@@ -21,9 +21,8 @@
       "cleanup": [ "*" ],
       "buildsystem": "simple",
       "build-commands": [
-	"sed -e 's/bdist_wheel/bdist/g' -i SConstruct",
-        "python3 scripts/scons.py --include-dir= -j1",
-	"python3 setup.py install --prefix=/app --skip-build --install-data=/app/share"
+        "python3 Script/scons.py --include-dir= -j1",
+        "python3 setup.py install --prefix=/app --skip-build --install-data=/app/share"
       ],
       "sources": [
         {


### PR DESCRIPTION
The line we were changing doesn't even exist anymore in the version of
the file that's in the latest tarball, so it's now a no-op.