### PR TITLE
Remove checker support for scons

### DIFF
--- a/io.github.endless_sky.endless_sky.json
+++ b/io.github.endless_sky.endless_sky.json
@@ -29,13 +29,7 @@
                 {
                     "type": "archive",
                     "url": "https://github.com/scons/scons/archive/4.1.0.tar.gz",
-                    "sha512": "f79b86bb09783767b3872cfb8efb665372714a604af2aaf3adc66eee63d3afe27bc6b2aab83813743c83f71c81c800d42842e916501787ba402ce2726dda9b44",
-                    "x-checker-data": {
-                    "type": "anitya",
-                    "project-id": 4770,
-                    "stable-only": true,
-                    "url-template": "https://sourceforge.net/projects/scons/files/scons/$version/SCons-$version.tar.gz"
-                    }
+                    "sha512": "f79b86bb09783767b3872cfb8efb665372714a604af2aaf3adc66eee63d3afe27bc6b2aab83813743c83f71c81c800d42842e916501787ba402ce2726dda9b44"
                 }
             ]
         },


### PR DESCRIPTION
Scons updates need to be manually handled as the underlying file
structure seems to always change. This means we can't rely on an
automatic system to do it for us, so there's no point in having
x-checker-data rsupport here.