### PR TITLE
Update permissions

### DIFF
--- a/io.github.endless_sky.endless_sky.json
+++ b/io.github.endless_sky.endless_sky.json
@@ -9,7 +9,8 @@
     "finish-args": [
         "--socket=pulseaudio",
         "--socket=wayland",
-        "--socket=x11",
+        "--socket=fallback-x11",
+        "--share=ipc",
         "--device=dri"
     ],
     "modules": [


### PR DESCRIPTION
This PR updates the permissions of the flatpak to prefer wayland over X11 (and adding a missing permission for X11 support), as requested by @Pointedstick.