### PR TITLE
Update to v0.9.16

### DIFF
--- a/io.github.endless_sky.endless_sky.json
+++ b/io.github.endless_sky.endless_sky.json
@@ -49,15 +49,14 @@
             "build-commands": [
                 "CPPPATH=/app/include python3 /app/scons/scons.py PREFIX=/app install -j $FLATPAK_BUILDER_N_JOBS",
                 "install -Dm755 launcher /app/bin/endless-sky",
-                "install -Dm644 endless-sky.appdata.xml /app/share/metainfo/io.github.endless_sky.endless_sky.appdata.xml",
                 "mkdir -p /app/share/games/endless-sky/plugins/",
                 "cp -r endless-sky-high-dpi /app/share/games/endless-sky/plugins/"
             ],
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://github.com/endless-sky/endless-sky/archive/refs/tags/v0.9.15.tar.gz",
-                    "sha256": "929fc51e8a3437a98eb92009d971d8c20793ab697dd72c26508b5cebbf8d430a",
+                    "url": "https://github.com/endless-sky/endless-sky/archive/refs/tags/v0.9.16.tar.gz",
+                    "sha256": "b4a699bc3761b9cf725cea6a3690e1598d8f400543722708cce211c5686c36e8",
                     "x-checker-data": {
                         "type": "anitya",
                         "project-id": 10359,
@@ -67,8 +66,8 @@
                 },
                 {
                     "type": "archive",
-                    "url": "https://github.com/endless-sky/endless-sky-high-dpi/archive/refs/tags/v0.9.15.tar.gz",
-                    "sha256": "338555a56df18704e713dc9c6f17f4ca66ad54d36e0102d5206afd2d0290b92a",
+                    "url": "https://github.com/endless-sky/endless-sky-high-dpi/archive/refs/tags/v0.9.16.tar.gz",
+                    "sha256": "f88e892e56910731eac14c108a406bfc05c5b72da2efa5c11b6598f1549f6480",
                     "dest": "endless-sky-high-dpi",
                     "x-checker-data": {
                         "type": "anitya",


### PR DESCRIPTION
This supersedes #16. v0.9.16 changed the name of the AppStream file, as such the install command that renamed the AppStream file is no longer necessary.