### PR TITLE
Make an extension point for plugins

### DIFF
--- a/io.github.endless_sky.endless_sky.json
+++ b/io.github.endless_sky.endless_sky.json
@@ -13,6 +13,16 @@
         "--share=ipc",
         "--device=dri"
     ],
+    "add-extensions": {
+        "io.github.endless_sky.endless_sky.plugins": {
+            "directory": "share/games/endless-sky/plugins",
+            "subdirectories": true
+        },
+        "io.github.endless_sky.endless_sky.plugins.endless-sky-high-dpi": {
+            "directory": "share/games/endless-sky/plugins/endless-sky-high-dpi",
+            "bundle": true
+        }
+    },
     "modules": [
         "shared-modules/glu/glu-9.json",
         "shared-modules/glew/glew.json",

--- a/io.github.endless_sky.endless_sky.json
+++ b/io.github.endless_sky.endless_sky.json
@@ -17,10 +17,6 @@
         "io.github.endless_sky.endless_sky.plugins": {
             "directory": "share/games/endless-sky/plugins",
             "subdirectories": true
-        },
-        "io.github.endless_sky.endless_sky.plugins.endless-sky-high-dpi": {
-            "directory": "share/games/endless-sky/plugins/endless-sky-high-dpi",
-            "bundle": true
         }
     },
     "modules": [


### PR DESCRIPTION
Previously, the endless-sky-high-dpi plugin was bundled with the app,
and there was no way that other plugins could be installed system-wide.

To address this:

- Define an extension point, io.github.endless_sky.endless_sky.plugins,
  with the 'subdirectories' flag set. This means that an extension named
  io.github.endless_sky.endless_sky.plugins.foo will be mounted at a
  subdirectory 'foo' of the given directory.

- Define the endless-sky-high-dpi extension as one such plugin.

Further plugins could be uploaded to Flathub in the
io.github.endless_sky.endless_sky.plugins.* namespace, and advanced
users could build & install their own plugins in that namespace.

TODO:

- [ ] The `endless-sky-high-dpi` plugin should include a metainfo file. This would make it show up as part of a checklist of extensions in GNOME Software's page for Endless Sky.

Fixes #22
