### PR TITLE
Stop using launcher script

### DIFF
--- a/fix-resources-search-path.patch
+++ b/fix-resources-search-path.patch
@@ -1,0 +1,13 @@
+diff --git a/source/Files.cpp b/source/Files.cpp
+index 1578073e8..4d33053e5 100644
+--- a/source/Files.cpp
++++ b/source/Files.cpp
+@@ -117,7 +117,7 @@ void Files::Init(const char * const *argv)
+ 	// Special case, for Linux: the resource files are not in the same place as
+ 	// the executable, but are under the same prefix (/usr or /usr/local).
+ 	static const string LOCAL_PATH = "/usr/local/";
+-	static const string STANDARD_PATH = "/usr/";
++	static const string STANDARD_PATH = "/app/";
+ 	static const string RESOURCE_PATH = "share/games/endless-sky/";
+ 	if(!resources.compare(0, LOCAL_PATH.length(), LOCAL_PATH))
+ 		resources = LOCAL_PATH + RESOURCE_PATH;

--- a/io.github.endless_sky.endless_sky.json
+++ b/io.github.endless_sky.endless_sky.json
@@ -48,7 +48,7 @@
             },
             "build-commands": [
                 "CPPPATH=/app/include python3 /app/scons/scons.py PREFIX=/app install -j $FLATPAK_BUILDER_N_JOBS",
-                "install -Dm755 launcher /app/bin/endless-sky",
+                "install -Dm755 /app/games/endless-sky /app/bin/endless-sky",
                 "mkdir -p /app/share/games/endless-sky/plugins/",
                 "cp -r endless-sky-high-dpi /app/share/games/endless-sky/plugins/"
             ],
@@ -77,15 +77,12 @@
                     }
                 },
                 {
-                    "type": "script",
-                    "dest-filename": "launcher",
-                    "commands": [
-                        "exec /app/games/endless-sky -r /app/share/games/endless-sky"
-                    ]
+                    "type": "patch",
+                    "path": "fix-license.patch"
                 },
                 {
                     "type": "patch",
-                    "path": "fix-license.patch"
+                    "path": "fix-resources-search-path.patch"
                 }
             ]
         }


### PR DESCRIPTION
Using a launcher script instead of the actual application meant that it was impossible to pass command line arguments to the game. Instead, patch the game to look for in `/app/` for the resource files, instead of `/usr/`.