### PR TITLE
Fix resource directory pathing

### DIFF
--- a/io.github.endless_sky.endless_sky.json
+++ b/io.github.endless_sky.endless_sky.json
@@ -46,6 +46,10 @@
                         "stable-only": true,
                         "url-template": "https://github.com/endless-sky/endless-sky/archive/refs/tags/v$version.tar.gz"
                     }
+                },
+                {
+                    "type": "patch",
+                    "path": "use-trailing-slash.patch"
                 }
             ]
         }

--- a/use-trailing-slash.patch
+++ b/use-trailing-slash.patch
@@ -1,17 +1,15 @@
 diff --git a/source/Files.cpp b/source/Files.cpp
-index bb03ecfc0..1aa613628 100644
+index f5dec21..8547efd 100644
 --- a/source/Files.cpp
 +++ b/source/Files.cpp
-@@ -124,10 +124,8 @@ void Files::Init(const char * const *argv)
+@@ -100,8 +100,8 @@ void Files::Init(const char * const *argv)
  #if defined __linux__ || defined __FreeBSD__ || defined __DragonFly__
- 		// Special case, for Linux: the resource files are not in the same place as
- 		// the executable, but are under the same prefix (/usr or /usr/local).
--		// When used as an iterator, a trailing / will create an empty item at
--		// the end, so parent paths do not include it.
--		static const filesystem::path LOCAL_PATH = "/usr/local";
--		static const filesystem::path STANDARD_PATH = "/usr";
-+		static const filesystem::path LOCAL_PATH = "/usr/local/";
-+		static const filesystem::path STANDARD_PATH = "/usr/";
- 		static const filesystem::path RESOURCE_PATH = "share/games/endless-sky/";
+ // Special case, for Linux: the resource files are not in the same place as
+ // the executable, but are under the same prefix (/usr or /usr/local).
+-static const filesystem::path LOCAL_PATH = "/usr/local/";
+-static const filesystem::path STANDARD_PATH = "/usr/";
++static const filesystem::path LOCAL_PATH = "/usr/local";
++static const filesystem::path STANDARD_PATH = "/usr";
+ static const filesystem::path RESOURCE_PATH = "share/games/endless-sky/";
  
- 		if(IsParent(LOCAL_PATH, resources))
+ const auto IsParent = [](const auto parent, const auto child) -> bool {

--- a/use-trailing-slash.patch
+++ b/use-trailing-slash.patch
@@ -3,13 +3,13 @@ index f5dec21..8547efd 100644
 --- a/source/Files.cpp
 +++ b/source/Files.cpp
 @@ -100,8 +100,8 @@ void Files::Init(const char * const *argv)
- #if defined __linux__ || defined __FreeBSD__ || defined __DragonFly__
- // Special case, for Linux: the resource files are not in the same place as
- // the executable, but are under the same prefix (/usr or /usr/local).
--static const filesystem::path LOCAL_PATH = "/usr/local/";
--static const filesystem::path STANDARD_PATH = "/usr/";
-+static const filesystem::path LOCAL_PATH = "/usr/local";
-+static const filesystem::path STANDARD_PATH = "/usr";
- static const filesystem::path RESOURCE_PATH = "share/games/endless-sky/";
- 
- const auto IsParent = [](const auto parent, const auto child) -> bool {
+#if defined __linux__ || defined __FreeBSD__ || defined __DragonFly__
+		// Special case, for Linux: the resource files are not in the same place as
+		// the executable, but are under the same prefix (/usr or /usr/local).
+-		static const filesystem::path LOCAL_PATH = "/usr/local/";
+-		static const filesystem::path STANDARD_PATH = "/usr/";
++		static const filesystem::path LOCAL_PATH = "/usr/local";
++		static const filesystem::path STANDARD_PATH = "/usr";
+		static const filesystem::path RESOURCE_PATH = "share/games/endless-sky/";
+
+		const auto IsParent = [](const auto parent, const auto child) -> bool {

--- a/use-trailing-slash.patch
+++ b/use-trailing-slash.patch
@@ -1,0 +1,17 @@
+diff --git a/source/Files.cpp b/source/Files.cpp
+index bb03ecfc0..1aa613628 100644
+--- a/source/Files.cpp
++++ b/source/Files.cpp
+@@ -124,10 +124,8 @@ void Files::Init(const char * const *argv)
+ #if defined __linux__ || defined __FreeBSD__ || defined __DragonFly__
+ 		// Special case, for Linux: the resource files are not in the same place as
+ 		// the executable, but are under the same prefix (/usr or /usr/local).
+-		// When used as an iterator, a trailing / will create an empty item at
+-		// the end, so parent paths do not include it.
+-		static const filesystem::path LOCAL_PATH = "/usr/local";
+-		static const filesystem::path STANDARD_PATH = "/usr";
++		static const filesystem::path LOCAL_PATH = "/usr/local/";
++		static const filesystem::path STANDARD_PATH = "/usr/";
+ 		static const filesystem::path RESOURCE_PATH = "share/games/endless-sky/";
+ 
+ 		if(IsParent(LOCAL_PATH, resources))


### PR DESCRIPTION
https://github.com/endless-sky/endless-sky/pull/11168/ removed the trailing slash from the resource directory. It seems Flathub's build system doesn't like that.
This PR adds a patch to revert that commit, which should in theory allow the game to run properly after installation via Flathub. See https://github.com/endless-sky/endless-sky/issues/11326#issuecomment-2849147081 for the bug report.