### PR TITLE
fix:clean patch apply after upstream fix of resources dir issue

### DIFF
--- a/io.github.endless_sky.endless_sky.json
+++ b/io.github.endless_sky.endless_sky.json
@@ -23,6 +23,7 @@
         "shared-modules/glu/glu-9.json",
         "shared-modules/glew/glew.json",
         "shared-modules/libmad/libmad.json",
+        "minizip.json",
         {
             "name": "endless-sky",
             "buildsystem": "cmake-ninja",

--- a/io.github.endless_sky.endless_sky.json
+++ b/io.github.endless_sky.endless_sky.json
@@ -1,7 +1,7 @@
 {
     "id": "io.github.endless_sky.endless_sky",
     "runtime": "org.freedesktop.Platform",
-    "runtime-version": "23.08",
+    "runtime-version": "25.08",
     "sdk": "org.freedesktop.Sdk",
     "command": "endless-sky",
     "rename-icon": "endless-sky",
@@ -38,8 +38,8 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://github.com/endless-sky/endless-sky/archive/refs/tags/v0.10.15.tar.gz",
-                    "sha256": "d6a8e901dc311d78077fd1a6a8faff77f386632c4650f76bee3daa4496e4c4f6",
+                    "url": "https://github.com/endless-sky/endless-sky/archive/refs/tags/v0.10.14.tar.gz",
+                    "sha256": "8e07349b7d33645f726efbb5fbe900a9f8c084084d4c8dea7d9165341e43eb6d", 
                     "x-checker-data": {
                         "type": "anitya",
                         "project-id": 10359,

--- a/io.github.endless_sky.endless_sky.json
+++ b/io.github.endless_sky.endless_sky.json
@@ -1,7 +1,7 @@
 {
     "id": "io.github.endless_sky.endless_sky",
     "runtime": "org.freedesktop.Platform",
-    "runtime-version": "25.08",
+    "runtime-version": "23.08",
     "sdk": "org.freedesktop.Sdk",
     "command": "endless-sky",
     "rename-icon": "endless-sky",

--- a/io.github.endless_sky.endless_sky.json
+++ b/io.github.endless_sky.endless_sky.json
@@ -38,8 +38,8 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://github.com/endless-sky/endless-sky/archive/refs/tags/v0.10.12.tar.gz",
-                    "sha256": "8082124478e4eaf1e795fc044f6e540804eded095d91fd2ff6a658c0d905f60c",
+                    "url": "https://github.com/endless-sky/endless-sky/archive/refs/tags/v0.10.15.tar.gz",
+                    "sha256": "d6a8e901dc311d78077fd1a6a8faff77f386632c4650f76bee3daa4496e4c4f6",
                     "x-checker-data": {
                         "type": "anitya",
                         "project-id": 10359,

--- a/minizip.json
+++ b/minizip.json
@@ -1,6 +1,6 @@
 {
   "name": "minizip",
-  "subdir": "contrib/minizip",
+  "builddir": "contrib/minizip",
   "buildsystem": "cmake-ninja",
   "sources": [
     {
@@ -9,5 +9,10 @@
       "tag": "v1.3.1",
       "commit": "51b7f2abdade71cd9bb0e7a373ef2610ec6f9daf"
     }
+  ]
+  "cleanup": [
+    "/include",
+    "/lib/pkgconfig",
+    "/lib/*.a"
   ]
 }

--- a/minizip.json
+++ b/minizip.json
@@ -1,0 +1,13 @@
+{
+  "name": "minizip",
+  "subdir": "contrib/minizip",
+  "buildsystem": "cmake-ninja",
+  "sources": [
+    {
+      "type": "git",
+      "url": "https://github.com/madler/zlib.git",
+      "tag": "v1.3.1",
+      "commit": "51b7f2abdade71cd9bb0e7a373ef2610ec6f9daf"
+    }
+  ]
+}

--- a/minizip.json
+++ b/minizip.json
@@ -9,7 +9,7 @@
       "tag": "v1.3.1",
       "commit": "51b7f2abdade71cd9bb0e7a373ef2610ec6f9daf"
     }
-  ]
+  ],
   "cleanup": [
     "/include",
     "/lib/pkgconfig",

--- a/use-app-not-usr-directory.patch
+++ b/use-app-not-usr-directory.patch
@@ -2,19 +2,21 @@ diff --git a/source/Files.cpp b/source/Files.cpp
 index f5dec211d..654ea2a5e 100644
 --- a/source/Files.cpp
 +++ b/source/Files.cpp
-@@ -99,9 +99,10 @@ void Files::Init(const char * const *argv)
+@@ -123,9 +123,10 @@ void Files::Init(const char * const *argv)
  
  #if defined __linux__ || defined __FreeBSD__ || defined __DragonFly__
  		// Special case, for Linux: the resource files are not in the same place as
 -		// the executable, but are under the same prefix (/usr or /usr/local).
 +		// the executable, but are under the same prefix (/usr or /usr/local or /app).
- 		static const filesystem::path LOCAL_PATH = "/usr/local/";
- 		static const filesystem::path STANDARD_PATH = "/usr/";
+		// When used as an iterator, a trailing / will create an empty item at
+		// the end, so parent paths do not include it.
+ 		static const filesystem::path LOCAL_PATH = "/usr/local";
+ 		static const filesystem::path STANDARD_PATH = "/usr";
 +		static const filesystem::path FLATHUB_PATH = "/app";
  		static const filesystem::path RESOURCE_PATH = "share/games/endless-sky/";
  
  		const auto IsParent = [](const auto parent, const auto child) -> bool {
-@@ -114,6 +115,8 @@ void Files::Init(const char * const *argv)
+@@ -134,6 +135,8 @@ void Files::Init(const char * const *argv)
  			resources = LOCAL_PATH / RESOURCE_PATH;
  		else if(IsParent(STANDARD_PATH, resources))
  			resources = STANDARD_PATH / RESOURCE_PATH;


### PR DESCRIPTION
Fixes issue #64 but only in theory. The patch file was manually edited against clean 10.15 source and the main branch version here and the same buildbot command was confirmed to complete with fuzz 2 but successfully. No build was attempted locally due to system constraints.